### PR TITLE
Add CUPT, the Cuban Peso Private Token

### DIFF
--- a/tokenlist.json
+++ b/tokenlist.json
@@ -1,16 +1,15 @@
 {
     "address": "TW63guytLiXrGU9KrVgduoHRXaubaUkn3T",
-    "symbol": "Huobi 2nd Space",
-    "name": "Huobi 2nd Space Club",
+    "symbol": "CUPT",
+    "name": "Cuban Peso (CUPT)",
     "decimals": 6,
-    "logoURI": "https://hbg-prod-fed-public.hbfile.net/nuwa/static/prod/56020150-434a-46af-9eaa-fe1ed404c12b.gif",
-    "homepage": "https://www.huobi.com/",
+    "logoURI": "https://qvpay.me/img/coins/cupt.svg",
+    "homepage": "https://qvpay.me/coins/CUPT",
     "existingMarkets": [
         {
-            "source": "ApeNFT",
+            "source": "Sunswap",
             "pairs": [
-                "Huobi 2nd Space/USDT",
-                "Huobi 2nd Space/TRX"
+                "CUPT/USDT"
             ]
         }
   ]

--- a/tokenlist.json
+++ b/tokenlist.json
@@ -1,5 +1,5 @@
 {
-    "address": "TW63guytLiXrGU9KrVgduoHRXaubaUkn3T",
+    "address": "TWpbdDLCV7Z4fpT35VaRCzunmWi72xKpc3",
     "symbol": "CUPT",
     "name": "Cuban Peso (CUPT)",
     "decimals": 6,


### PR DESCRIPTION
## **Please provide the following information for your token.**

Please include change to the `tokenlist.json` file in the PR.
DON'T modify any other token on the list.

At minimum each entry should have

- Token Address: TWpbdDLCV7Z4fpT35VaRCzunmWi72xKpc3
- Token Name: Cuban Peso
- Token Symbol: CUPT
- Token Decimal: 6
- Logo URI:  https://qvpay.me/img/coins/cupt.svg
- Link to the official homepage of token: https://qvpay.me/coins/CUPT
- MarketCap Link if available (https://coinmarketcap.com/currencies/#TOKEN or https://www.coingecko.com/en/coins/#TOKEN):
- Existing Markets (where to trade): Sunswap
